### PR TITLE
Python3 migration

### DIFF
--- a/examples/constrained/branin_con.py
+++ b/examples/constrained/branin_con.py
@@ -6,7 +6,7 @@ def evaluate(job_id, params):
     x = params['X']
     y = params['Y']
 
-    print 'Evaluating at (%f, %f)' % (x, y)
+    print('Evaluating at (%f, %f)' % (x, y))
 
     if x < 0 or x > 5.0 or y > 5.0:
         return np.nan
@@ -30,6 +30,6 @@ def main(job_id, params):
     try:
         return evaluate(job_id, params)
     except Exception as ex:
-        print ex
-        print 'An error occurred in branin_con.py'
+        print(ex)
+        print('An error occurred in branin_con.py')
         return np.nan

--- a/examples/distributed/branin.py
+++ b/examples/distributed/branin.py
@@ -13,12 +13,12 @@ def branin(x, y):
   #if np.random.rand > 0.75:
   #  raise Exception('Blah!')
 
-  print 'Result = %f' % result
+  print('Result = %f' % result)
   time.sleep(np.random.randint(30))
   return {'branin' : result}
 
 # Write a function like this called 'main'
 def main(job_id, params):
-  print 'Anything printed here will end up in the output directory for job #%d' % job_id
-  print params
+  print('Anything printed here will end up in the output directory for job #%d' % job_id)
+  print(params)
   return branin(params['x'], params['y'])

--- a/examples/noisy/branin_noisy.py
+++ b/examples/noisy/branin_noisy.py
@@ -9,12 +9,12 @@ def branin(x, y):
     result = float(result)
     noise = np.random.normal() * 50.
     
-    print 'Result = %f, noise %f, total %f' % (result, noise, result+noise)
+    print('Result = %f, noise %f, total %f' % (result, noise, result+noise))
     #time.sleep(np.random.randint(60))
     return result + noise
 
 # Write a function like this called 'main'
 def main(job_id, params):
-    print 'Anything printed here will end up in the output directory for job #%d' % job_id
-    print params
+    print('Anything printed here will end up in the output directory for job #%d' % job_id)
+    print(params)
     return branin(params['x'], params['y'])

--- a/examples/simple/branin.py
+++ b/examples/simple/branin.py
@@ -8,12 +8,12 @@ def branin(x, y):
     
     result = float(result)
     
-    print 'Result = %f' % result
+    print('Result = %f' % result)
     #time.sleep(np.random.randint(60))
     return result
 
 # Write a function like this called 'main'
 def main(job_id, params):
-    print 'Anything printed here will end up in the output directory for job #%d' % job_id
-    print params
+    print('Anything printed here will end up in the output directory for job #%d' % job_id)
+    print(params)
     return branin(params['x'], params['y'])

--- a/examples/simple/make_plots.py
+++ b/examples/simple/make_plots.py
@@ -1,6 +1,6 @@
 import importlib
 import sys
-from itertools import izip
+
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -14,12 +14,12 @@ from spearmint.main import get_options, parse_resources_from_config, load_jobs, 
 
 def print_dict(d, level=1):
     if isinstance(d, dict):
-        if level > 1: print ""
-        for k, v in d.iteritems():
-            print "  " * level, k,
+        if level > 1: print("")
+        for k, v in d.items():
+            print("  " * level, k, end=' ')
             print_dict(v, level=level+1)
     else:
-        print d 
+        print(d) 
 
 def main():
     """
@@ -32,7 +32,7 @@ def main():
     unstandardized)
     """
     options, expt_dir = get_options()
-    print "options:"
+    print("options:")
     print_dict(options)
     
     # reduce the grid size
@@ -43,7 +43,7 @@ def main():
     # Load up the chooser.
     chooser_module = importlib.import_module('spearmint.choosers.' + options['chooser'])
     chooser = chooser_module.init(options)
-    print "chooser", chooser
+    print("chooser", chooser)
     experiment_name     = options.get("experiment-name", 'unnamed-experiment')
 
     # Connect to the database
@@ -55,38 +55,38 @@ def main():
     jobs = load_jobs(db, experiment_name)
     remove_broken_jobs(db, jobs, experiment_name, resources)
 
-    print "resources:", resources
+    print("resources:", resources)
     print_dict(resources)
-    resource = resources.itervalues().next()
+    resource = next(iter(resources.values()))
     
     task_options = { task: options["tasks"][task] for task in resource.tasks }
-    print "task_options:"
+    print("task_options:")
     print_dict(task_options) # {'main': {'likelihood': u'NOISELESS', 'type': 'OBJECTIVE'}}
     
     task_group = load_task_group(db, options, resource.tasks)
-    print "task_group", task_group # TaskGroup
-    print "tasks:"
+    print("task_group", task_group) # TaskGroup
+    print("tasks:")
     print_dict(task_group.tasks) # {'main': <spearmint.tasks.task.Task object at 0x10bf63290>}
     
     
     hypers = load_hypers(db, experiment_name)
-    print "loaded hypers", hypers # from GP.to_dict()
+    print("loaded hypers", hypers) # from GP.to_dict()
     
     hypers = chooser.fit(task_group, hypers, task_options)
-    print "\nfitted hypers:"
+    print("\nfitted hypers:")
     print_dict(hypers)
 
     lp, x = chooser.best()
     x = x.flatten()
-    print "best", lp, x
+    print("best", lp, x)
     bestp = task_group.paramify(task_group.from_unit(x))
-    print "expected best position", bestp
+    print("expected best position", bestp)
     
     # get the grid of points
     grid = chooser.grid
 #     print "chooser objectives:", 
 #     print_dict(chooser.objective)
-    print "chooser models:", chooser.models
+    print("chooser models:", chooser.models)
     print_dict(chooser.models)
     obj_model = chooser.models[chooser.objective['name']]
     obj_mean, obj_var = obj_model.function_over_hypers(obj_model.predict, grid)
@@ -100,15 +100,15 @@ def main():
 #     for xy, m, v in izip(grid, obj_mean, obj_var):
 #         print xy, m, v
 
-    grid = map(task_group.from_unit, grid)
+    grid = list(map(task_group.from_unit, grid))
 #     return
     
-    xymv = [(xy[0], xy[1], m, v) for xy, m, v in izip(grid, obj_mean, obj_std)]# if .2 < xy[0] < .25] 
+    xymv = [(xy[0], xy[1], m, v) for xy, m, v in zip(grid, obj_mean, obj_std)]# if .2 < xy[0] < .25] 
     
-    x = map(lambda x:x[0], xymv)
-    y = map(lambda x:x[1], xymv)
-    m = map(lambda x:x[2], xymv)
-    sig = map(lambda x:x[3], xymv)
+    x = [x[0] for x in xymv]
+    y = [x[1] for x in xymv]
+    m = [x[2] for x in xymv]
+    sig = [x[3] for x in xymv]
 #     print y
     
     fig = plt.figure(dpi=100)
@@ -124,7 +124,7 @@ def main():
     task = task_group.tasks['main']
     idata = task.valid_normalized_data_dict
     xy = idata["inputs"]
-    xy = map(task_group.from_unit, xy)
+    xy = list(map(task_group.from_unit, xy))
     xy = np.array(xy)
     vals = idata["values"]
     vals = [obj_task.unstandardize_mean(obj_task.unstandardize_variance(v)) for v in vals]

--- a/spearmint/__init__.py
+++ b/spearmint/__init__.py
@@ -110,7 +110,7 @@ class Experiment:
                  #db_uri='mongodb://spmint.chestimagingplatform.org/spearmint',
                  db_uri='',
                  likelihood='GAUSSIAN'): # other option is NOISELESS
-        for pval in parameters.itervalues():
+        for pval in parameters.values():
             pval['size'] = 1 # add default size = 1
             if pval['type'] == 'integer':
                 pval['type'] = 'int' # spearmint int type
@@ -158,7 +158,7 @@ class Experiment:
         return params_simple
 
     def load_task_group(self, jobs):
-        task_names = self.tasks.keys()
+        task_names = list(self.tasks.keys())
         task_group = TaskGroup(self.tasks, self.parameters)
 
         if jobs:

--- a/spearmint/choosers/acquisition_functions.py
+++ b/spearmint/choosers/acquisition_functions.py
@@ -191,7 +191,7 @@ import numpy.random   as npr
 import scipy.linalg   as spla
 import scipy.stats    as sps
 import scipy.optimize as spo
-import cPickle
+import pickle
 import multiprocessing
 import ast
 

--- a/spearmint/grids/sobol.py
+++ b/spearmint/grids/sobol.py
@@ -183,7 +183,7 @@
 # its Institution.
 
 import numpy as np
-import cPickle as pickle
+import pickle as pickle
 
 # Numba autojit might be nice.  Currently asplodes.
 def sobol(num_points, num_dims):
@@ -209,7 +209,7 @@ def sobol(num_points, num_dims):
     params = get_params()
 
     # Loop over dimensions
-    for dd in xrange(1,num_dims):
+    for dd in range(1,num_dims):
         s = params[dd-1]['s']
         a = params[dd-1]['a']
         m = params[dd-1]['m']
@@ -219,16 +219,16 @@ def sobol(num_points, num_dims):
             V[dd,:] = m << np.arange(31, 31-num_bits, -1, dtype=np.uint32)
         else:
             V[dd,:s] = m << np.arange(31, 31-s, -1, dtype=np.uint32)
-            for s0 in xrange(s, num_bits):
+            for s0 in range(s, num_bits):
                 V[dd,s0] = V[dd,s0-s] ^ (V[dd,s0-s] >> s)
-                for s1 in xrange(s-1):
+                for s1 in range(s-1):
                     V[dd,s0] = V[dd,s0] ^ (((a >> (s-2-s1)) & 1) * V[dd,s0-s1-1])
 
     X = np.zeros((num_points, num_dims), dtype=np.uint32)
 
     # Wish we could do this without recursion.
     # Fancy loop unrolling?
-    for nn in xrange(1,num_points):
+    for nn in range(1,num_points):
         X[nn,:] = X[nn-1,:] ^ V[:,C[nn-1]-1]
 
     Z = X.astype('double') / float(1<<32)

--- a/spearmint/grids/sobol.py
+++ b/spearmint/grids/sobol.py
@@ -240,7 +240,7 @@ def to_binary(X, bits):
 
 # These are the parameters for the Sobol sequence.
 # This is hilarious.
-params = """(lp1
+params = b"""(lp1
 (dp2
 S'a'
 I0

--- a/spearmint/grids/sobol.py
+++ b/spearmint/grids/sobol.py
@@ -236,7 +236,7 @@ def sobol(num_points, num_dims):
     return Z
 
 def to_binary(X, bits):
-    return 1 & (X[:,np.newaxis]/2**np.arange(bits-1,-1,-1, dtype=np.uint32))
+    return 1 & (X[:,np.newaxis] // 2**np.arange(bits-1,-1,-1, dtype=np.uint32))
 
 # These are the parameters for the Sobol sequence.
 # This is hilarious.

--- a/spearmint/kernels/__init__.py
+++ b/spearmint/kernels/__init__.py
@@ -1,8 +1,8 @@
-from matern           import Matern52
-from sum_kernel       import SumKernel
-from product_kernel   import ProductKernel
-from noise            import Noise
-from scale            import Scale
-from transform_kernel import TransformKernel
+from .matern           import Matern52
+from .sum_kernel       import SumKernel
+from .product_kernel   import ProductKernel
+from .noise            import Noise
+from .scale            import Scale
+from .transform_kernel import TransformKernel
 
 __all__ = ["Matern52", "SumKernel", "ProductKernel", "Noise", "Scale", "TransformKernel"]

--- a/spearmint/kernels/abstract_kernel.py
+++ b/spearmint/kernels/abstract_kernel.py
@@ -186,9 +186,7 @@ import numpy as np
 
 from abc import ABCMeta, abstractmethod
 
-class AbstractKernel(object):
-    __metaclass__ = ABCMeta
-
+class AbstractKernel(object, metaclass=ABCMeta):
     @property
     def hypers(self):
         return None

--- a/spearmint/kernels/kernel_utils.py
+++ b/spearmint/kernels/kernel_utils.py
@@ -184,11 +184,12 @@
 
 
 import numpy as np
-import scipy
-if scipy.__version__ > "0.18.1":
-    import weave as spweave
-else:
-    import scipy.weave as spweave
+# weave is not supported in Python 3 scipy
+# import scipy
+# if scipy.__version__ > "0.18.1":
+#     import weave as spweave
+# else:
+#     import scipy.weave as spweave
 from scipy.spatial.distance import cdist
 
 def dist2(ls, x1, x2=None):
@@ -224,21 +225,24 @@ def grad_dist2(ls, x1, x2=None):
     D = x1.shape[1]
     gX = np.zeros((x1.shape[0],x2.shape[0],x1.shape[1]))
 
-    code = \
-    """
-    for (int i=0; i<N; i++)
-      for (int j=0; j<M; j++)
-        for (int d=0; d<D; d++)
-          gX(i,j,d) = (2/ls(d))*(x1(i,d) - x2(j,d));
-    """
-    try:
-        spweave.inline(code, ['x1','x2','gX','ls','M','N','D'], \
-                           type_converters=spweave.converters.blitz, \
-                           compiler='gcc')
-    except:
-    # The C code weave above is 10x faster than this:
-        for i in range(0,x1.shape[0]):
-            gX[i,:,:] = 2*(x1[i,:] - x2[:,:])*(1/ls)
+    # code = \
+    # """
+    # for (int i=0; i<N; i++)
+    #   for (int j=0; j<M; j++)
+    #     for (int d=0; d<D; d++)
+    #       gX(i,j,d) = (2/ls(d))*(x1(i,d) - x2(j,d));
+    # """
+    # try:
+    #     spweave.inline(code, ['x1','x2','gX','ls','M','N','D'], \
+    #                        type_converters=spweave.converters.blitz, \
+    #                        compiler='gcc')
+    # except:
+    # # The C code weave above is 10x faster than this:
+
+    # weave is not supported in Python 3 scipy, so we use the original Python code here which was originally in the
+    # except clause of the above code commented out.
+    for i in range(0,x1.shape[0]):
+        gX[i,:,:] = 2*(x1[i,:] - x2[:,:])*(1/ls)
 
     return gX
 

--- a/spearmint/kernels/kernel_utils.py
+++ b/spearmint/kernels/kernel_utils.py
@@ -237,7 +237,7 @@ def grad_dist2(ls, x1, x2=None):
                            compiler='gcc')
     except:
     # The C code weave above is 10x faster than this:
-        for i in xrange(0,x1.shape[0]):
+        for i in range(0,x1.shape[0]):
             gX[i,:,:] = 2*(x1[i,:] - x2[:,:])*(1/ls)
 
     return gX

--- a/spearmint/kernels/matern.py
+++ b/spearmint/kernels/matern.py
@@ -184,7 +184,7 @@
 
 
 import numpy as np
-import kernel_utils
+from . import kernel_utils
 
 from .abstract_kernel import AbstractKernel
 from ..utils          import priors

--- a/spearmint/kernels/product.py
+++ b/spearmint/kernels/product.py
@@ -189,7 +189,7 @@
 import sys
 import numpy as np
 import priors
-import kernel_utils
+from . import kernel_utils
 import scipy.stats as sps
 import warnings
 import scipy.special as spe
@@ -217,7 +217,7 @@ class productCov:
             Ks = list()
             dKs = list()
             cov_grad = np.zeros((x1.shape[0], 1, x2.shape[1]))
-            for i in xrange(len(self.kernels)):
+            for i in range(len(self.kernels)):
                 (K, dK) = self.kernels[i].kernel(x1[:,self.dim_indices[i]],
                                                  x2[:,self.dim_indices[i]],
                                                  grad)
@@ -225,12 +225,12 @@ class productCov:
                 dKs.append(dK)
                 cov = cov * K
 
-            for i in xrange(len(self.kernels)):
+            for i in range(len(self.kernels)):
                 cov_grad[:, :, self.dim_indices[i]] = (cov_grad[:, :, self.dim_indices[i]] +
                                                        dKs[i] * (cov / Ks[i])[:,:,np.newaxis])
             return (cov, cov_grad)
         else:
-            for i in xrange(len(self.kernels)):
+            for i in range(len(self.kernels)):
                 cov = cov * self.kernels[i].kernel(x1[:,self.dim_indices[i]],
                                                    x2[:,self.dim_indices[i]],
                                                    grad)

--- a/spearmint/kernels/product_kernel.py
+++ b/spearmint/kernels/product_kernel.py
@@ -186,6 +186,7 @@
 import numpy as np
 
 from .abstract_kernel import AbstractKernel
+from functools import reduce
 
 
 class ProductKernel(AbstractKernel):

--- a/spearmint/kernels/sum_kernel.py
+++ b/spearmint/kernels/sum_kernel.py
@@ -184,6 +184,7 @@
 
 
 from .abstract_kernel import AbstractKernel
+from functools import reduce
 
 
 class SumKernel(AbstractKernel):

--- a/spearmint/launcher.py
+++ b/spearmint/launcher.py
@@ -257,21 +257,21 @@ def launch(db_address, experiment_name, job_id):
                 # Apparently this dict generator throws an error for some people??
                 # result = {task_name: np.nan for task_name in job['tasks']}
                 # So we use the much uglier version below... ????
-                result = dict(zip(job['tasks'], [np.nan]*len(job['tasks'])))
+                result = dict(list(zip(job['tasks'], [np.nan]*len(job['tasks']))))
             elif len(job['tasks']) == 1: # Only one named job
                 result = {job['tasks'][0] : result}
             else:
                 result = {'main' : result}
         
         if set(result.keys()) != set(job['tasks']):
-            raise Exception("Result task names %s did not match job task names %s." % (result.keys(), job['tasks']))
+            raise Exception("Result task names %s did not match job task names %s." % (list(result.keys()), job['tasks']))
 
         success = True
     except:
         import traceback
         traceback.print_exc()
         sys.stderr.write("Problem executing the function\n")
-        print sys.exc_info()
+        print(sys.exc_info())
         
     end_time = time.time()
 
@@ -305,7 +305,7 @@ def python_launcher(job):
 
     # Convert the JSON object into useful parameters.
     params = {}
-    for name, param in job['params'].iteritems():
+    for name, param in job['params'].items():
         vals = param['values']
 
         if param['type'].lower() == 'float':
@@ -351,7 +351,7 @@ def matlab_launcher(job):
     session.run("cd('%s')" % os.path.realpath(job['expt_dir']))
 
     session.run('params = struct()')
-    for name, param in job['params'].iteritems():
+    for name, param in job['params'].items():
         vals = param['values']
 
         # sys.stderr.write('%s = %s\n' % (param['name'], str(vals)))
@@ -400,7 +400,7 @@ def mcr_launcher(job):
     # Change into the directory.
     os.chdir(job['expt_dir'])
 
-    if os.environ.has_key('MATLAB'):
+    if 'MATLAB' in os.environ:
         mcr_loc = os.environ['MATLAB']
     else:
         raise Exception("Please set the MATLAB environment variable")

--- a/spearmint/main.py
+++ b/spearmint/main.py
@@ -262,7 +262,7 @@ def main():
     
     while True:
 
-        for resource_name, resource in resources.iteritems():
+        for resource_name, resource in resources.items():
 
             jobs = load_jobs(db, experiment_name)
             # resource.printStatus(jobs)
@@ -301,7 +301,7 @@ def main():
 
                 # Print out the status of the resources
                 # resource.printStatus(jobs)
-                print_resources_status(resources.values(), jobs)
+                print_resources_status(list(resources.values()), jobs)
 
         # If no resources are accepting jobs, sleep
         # (they might be accepting if suggest takes a while and so some jobs already finished by the time this point is reached)
@@ -313,7 +313,7 @@ def tired(db, experiment_name, resources):
     return True if no resources are accepting jobs
     """
     jobs = load_jobs(db, experiment_name)
-    for resource_name, resource in resources.iteritems():
+    for resource_name, resource in resources.items():
         if resource.acceptingJobs(jobs):
             return False
     return True
@@ -431,7 +431,7 @@ def save_job(job, db, experiment_name):
 
 def load_task_group(db, options, task_names=None):
     if task_names is None:
-        task_names = options['tasks'].keys()
+        task_names = list(options['tasks'].keys())
     task_options = { task: options["tasks"][task] for task in task_names }
 
     jobs = load_jobs(db, options['experiment-name'])

--- a/spearmint/models/__init__.py
+++ b/spearmint/models/__init__.py
@@ -1,4 +1,4 @@
-from gp            import GP
-from gp_classifier import GPClassifier
+from .gp            import GP
+from .gp_classifier import GPClassifier
 
 __all__ = ["GP", "GPClassifier"]

--- a/spearmint/models/abstract_model.py
+++ b/spearmint/models/abstract_model.py
@@ -185,10 +185,9 @@
 import numpy        as np
 
 from abc import ABCMeta, abstractmethod
+from functools import reduce
 
-class AbstractModel(object):
-    __metaclass__ = ABCMeta
-
+class AbstractModel(object, metaclass=ABCMeta):
     @abstractmethod
     def to_dict(self):
         pass
@@ -222,9 +221,9 @@ def function_over_hypers(models, fun, *fun_args, **fun_kwargs):
     """
 
     # The the minimum of the number of states over the different models
-    min_num_states = reduce(min, map(lambda x: x.num_states, models), np.inf)
+    min_num_states = reduce(min, [x.num_states for x in models], np.inf)
     
-    for i in xrange(min_num_states):
+    for i in range(min_num_states):
 
         for model in models:
             model.set_state(i)
@@ -243,7 +242,7 @@ def function_over_hypers(models, fun, *fun_args, **fun_kwargs):
 
         if isTuple:
             assert(len(result) == len(average))
-            for j in xrange(len(average)):
+            for j in range(len(average)):
                 assert(result[j].shape == average[j].shape)
                 average[j] += result[j]
         else:
@@ -252,7 +251,7 @@ def function_over_hypers(models, fun, *fun_args, **fun_kwargs):
     
     # Divide by numAveraged to get the average (right now we just have the sum)
     if isTuple:
-        for j in xrange(len(average)):
+        for j in range(len(average)):
             average[j] /= min_num_states
     else:
         average /= min_num_states

--- a/spearmint/models/gp.py
+++ b/spearmint/models/gp.py
@@ -201,7 +201,7 @@ try:
     log    = logging.getLogger(module)
 except:
     log    = logging.getLogger()
-    print 'Not running from main.'
+    print('Not running from main.')
 
 DEFAULT_MCMC_ITERS = 10
 DEFAULT_BURNIN     = 100
@@ -274,11 +274,11 @@ class GP(AbstractModel):
             self.noiseless = False
 
     def _set_params_from_dict(self, hypers_dict):
-        for name, hyper in self.params.iteritems():
+        for name, hyper in self.params.items():
             self.params[name].value = hypers_dict[name]
 
     def _reset_params(self):
-        for param in self.params.values():
+        for param in list(self.params.values()):
             param.value = param.initial_value
 
     def _pull_from_cache_or_compute(self):
@@ -293,7 +293,7 @@ class GP(AbstractModel):
 
     def _prepare_cache(self):
         inputs_hash = hash(self.inputs.tostring())
-        for i in xrange(self.num_states):
+        for i in range(self.num_states):
             self.set_state(i)
             chol  = spla.cholesky(self.kernel.cov(self.inputs), lower=True)
             alpha = spla.cho_solve((chol, True), self.values - self.mean.value)
@@ -365,7 +365,7 @@ class GP(AbstractModel):
         self._samplers.append(SliceSampler(ls, beta_alpha, beta_beta, compwise=True, thinning=self.thinning))
 
     def _burn_samples(self, num_samples):
-        for i in xrange(num_samples):
+        for i in range(num_samples):
             for sampler in self._samplers:
                 sampler.sample(self)
 
@@ -373,7 +373,7 @@ class GP(AbstractModel):
 
     def _collect_samples(self, num_samples):
         hypers_list = []
-        for i in xrange(num_samples):
+        for i in range(num_samples):
             for sampler in self._samplers:
                 sampler.sample(self)
 
@@ -384,7 +384,7 @@ class GP(AbstractModel):
 
     def _collect_fantasies(self, pending):
         fantasy_values_list = []
-        for i in xrange(self.num_states):
+        for i in range(self.num_states):
             self.set_state(i)
             fantasy_vals = self._fantasize(pending)
             if fantasy_vals.ndim == 1:
@@ -463,7 +463,7 @@ class GP(AbstractModel):
     def to_dict(self):
         """return a dictionary that saves the values of the hypers and the chain length"""
         gp_dict = {'hypers' : {}}
-        for name, hyper in self.params.iteritems():
+        for name, hyper in self.params.items():
             gp_dict['hypers'][name] = hyper.value
 
         gp_dict['chain length'] = self.chain_length
@@ -641,7 +641,7 @@ class GP(AbstractModel):
     # sampling y from p(y | theta)
     def sample_from_prior(self, pred, n_samples=1, joint=True):
         fants = np.zeros((pred.shape[0], n_samples))
-        for i in xrange(n_samples):
+        for i in range(n_samples):
             for param in self.params:
                 param.sample_from_prior() # sample from hyperpriors and set value
             fants[:,i] = self.sample_from_prior_given_hypers(pred, joint)
@@ -664,7 +664,7 @@ class GP(AbstractModel):
     # sampling y from p(y | theta, data)
     def sample_from_posterior_given_data(self, pred, n_samples=1, joint=True):
         fants = np.zeros((pred.shape[0], n_samples))
-        for i in xrange(n_samples):
+        for i in range(n_samples):
             # Sample theta from p(theta | data)
             self.generate_sample(1)
             # Sample y from p(y | theta, data)

--- a/spearmint/models/gp_classifier.py
+++ b/spearmint/models/gp_classifier.py
@@ -191,12 +191,6 @@ import scipy.linalg      as spla
 import scipy.optimize    as spo
 import scipy.io          as sio
 import scipy.stats       as sps
-import scipy
-if scipy.__version__ > "0.18.1":
-    import weave as spweave
-else:
-    import scipy.weave as spweave
-
 
 from .gp                                     import GP
 from ..utils.param                           import Param as Hyperparameter

--- a/spearmint/models/gp_classifier.py
+++ b/spearmint/models/gp_classifier.py
@@ -212,7 +212,7 @@ try:
     log    = logging.getLogger(module)
 except:
     log = logging.getLogger()
-    print 'Not running from main.'
+    print('Not running from main.')
 
 class GPClassifier(GP):
     def __init__(self, num_dims, **options):
@@ -287,7 +287,7 @@ class GPClassifier(GP):
         default_latent_values = self.counts - 0.5
 
         latent_values = np.zeros(self._inputs.shape[0])
-        for i in xrange(self._inputs.shape[0]):
+        for i in range(self._inputs.shape[0]):
             key = str(hash(self._inputs[i].tostring()))
             
             if key in latent_values_dict:
@@ -300,7 +300,7 @@ class GPClassifier(GP):
     def _burn_samples(self, num_samples):
         # sys.stderr.write('GPClassifer: burning %s: ' % ', '.join(self.params.keys()))
         # sys.stderr.write('%04d/%04d' % (0, num_samples))
-        for i in xrange(num_samples):
+        for i in range(num_samples):
             # sys.stderr.write('\b'*9+'%04d/%04d' % (i, num_samples))
             for sampler in self._samplers:
                 sampler.sample(self)
@@ -316,7 +316,7 @@ class GPClassifier(GP):
         # sys.stderr.write('%04d/%04d' % (0, num_samples))
         hypers_list        = []
         latent_values_list = []
-        for i in xrange(num_samples):
+        for i in range(num_samples):
             # sys.stderr.write('\b'*9+'%04d/%04d' % (i, num_samples))
             for sampler in self._samplers:
                 sampler.sample(self)
@@ -480,14 +480,14 @@ class GPClassifier(GP):
         gp_dict = {}
 
         gp_dict['hypers'] = {}
-        for name, hyper in self.params.iteritems():
+        for name, hyper in self.params.items():
             gp_dict['hypers'][name] = hyper.value
 
         # Save the latent values as a dict with keys as hashes of the data
         # so that each latent value is associated with its input
         # then when we load them in we know which ones are which
         gp_dict['latent values'] = {str(hash(self._inputs[i].tostring())) : self.latent_values.value[i] 
-                for i in xrange(self._inputs.shape[0])}
+                for i in range(self._inputs.shape[0])}
 
         gp_dict['chain length'] = self.chain_length
 

--- a/spearmint/resources/resource.py
+++ b/spearmint/resources/resource.py
@@ -189,6 +189,7 @@ import importlib
 from operator import add
 import numpy as np
 import sys
+from functools import reduce
 
 def parse_resources_from_config(config):
     """Parse the config dict and return a dictionary of resource objects keyed by resource name"""
@@ -202,7 +203,7 @@ def parse_resources_from_config(config):
     # If resources are specified
     else:
         resources = dict()
-        for resource_name, resource_opts in config["resources"].iteritems():
+        for resource_name, resource_opts in config["resources"].items():
             task_names = parse_tasks_in_resource_from_config(config, resource_name)
             resources[resource_name] = resource_factory(resource_name, task_names, resource_opts)
         return resources
@@ -217,7 +218,7 @@ def parse_tasks_in_resource_from_config(config, resource_name):
         return ['main']
     else:
         tasks = list()
-        for task_name, task_config in config["tasks"].iteritems():
+        for task_name, task_config in config["tasks"].items():
             # If the user specified tasks but not specific resources for those tasks,
             # We have to assume the tasks run on all resources...
             if "resources" not in task_config:
@@ -297,14 +298,14 @@ class Resource(object):
     def filterMyJobs(self, jobs):
         """Take a list of jobs and filter only those that are running/run on this resource"""
         if jobs:
-            return filter(lambda job: job['resource']==self.name, jobs)
+            return [job for job in jobs if job['resource']==self.name]
         else:
             return jobs
 
     def numPending(self, jobs):
         jobs = self.filterMyJobs(jobs)
         if jobs:
-            pending_jobs = map(lambda x: x['status'] in ['pending', 'new'], jobs)
+            pending_jobs = [x['status'] in ['pending', 'new'] for x in jobs]
             return reduce(add, pending_jobs, 0)
         else:
             return 0
@@ -312,7 +313,7 @@ class Resource(object):
     def numComplete(self, jobs):
         jobs = self.filterMyJobs(jobs)
         if jobs:
-            completed_jobs = map(lambda x: x['status'] == 'complete', jobs)
+            completed_jobs = [x['status'] == 'complete' for x in jobs]
             return reduce(add, completed_jobs, 0)
         else:
             return 0

--- a/spearmint/sampling/__init__.py
+++ b/spearmint/sampling/__init__.py
@@ -1,6 +1,6 @@
-from abstract_sampler             import AbstractSampler
-from slice_sampler                import SliceSampler
-from whitened_prior_slice_sampler import WhitenedPriorSliceSampler
-from elliptical_slice_sampler     import EllipticalSliceSampler
+from .abstract_sampler             import AbstractSampler
+from .slice_sampler                import SliceSampler
+from .whitened_prior_slice_sampler import WhitenedPriorSliceSampler
+from .elliptical_slice_sampler     import EllipticalSliceSampler
 
 __all__ = ["AbstractSampler", "SliceSampler", "WhitenedPriorSliceSampler", "EllipticalSliceSampler"]

--- a/spearmint/sampling/abstract_sampler.py
+++ b/spearmint/sampling/abstract_sampler.py
@@ -188,9 +188,7 @@ from abc import ABCMeta, abstractmethod
 from ..utils import param as hyperparameter_utils
 
 
-class AbstractSampler(object):
-    __metaclass__ = ABCMeta
-
+class AbstractSampler(object, metaclass=ABCMeta):
     def __init__(self, *params_to_sample, **sampler_options):
         self.params          = params_to_sample
         self.sampler_options = sampler_options
@@ -199,7 +197,7 @@ class AbstractSampler(object):
         # Note: thinning is currently implemented such that each sampler does its thinning
         # We could also do a different type of thinning, implemented in SamplerCollection,
         # where all samplers produce a sample, and then you thin (ABABAB rather than AAABBB)
-        self.thinning_overrideable = not sampler_options.has_key('thinning') # Thinning can be overrided if True
+        self.thinning_overrideable = 'thinning' not in sampler_options # Thinning can be overrided if True
         self.thinning              = sampler_options.get('thinning', 0)
 
     @abstractmethod

--- a/spearmint/sampling/elliptical_slice_sampler.py
+++ b/spearmint/sampling/elliptical_slice_sampler.py
@@ -210,7 +210,7 @@ class EllipticalSliceSampler(AbstractSampler):
         # Here get the Cholesky from model
 
         params_array = hyperparameter_utils.params_to_array(self.params)
-        for i in xrange(self.thinning + 1):
+        for i in range(self.thinning + 1):
             params_array, current_ll = elliptical_slice(
                 params_array,
                 self.logprob,
@@ -292,7 +292,7 @@ if __name__ == '__main__':
     from utils import priors
     import time
 
-    print '2D Gaussian:'
+    print('2D Gaussian:')
 
     n = 1000000
 
@@ -312,20 +312,20 @@ if __name__ == '__main__':
     like_cov = np.dot(like_L, like_L.T)
     like = priors.MultivariateNormal(mu=like_mu, cov=like_cov)
 
-    print 'Prior cov:'
-    print prior_cov
-    print 'Like cov:'
-    print like_cov
+    print('Prior cov:')
+    print(prior_cov)
+    print('Like cov:')
+    print(like_cov)
 
     current_time = time.time()
     cur_ll = None
-    for i in xrange(n):
+    for i in range(n):
         if i % 1000 == 0:
-            print 'Elliptical Slice Sample %d/%d' % (i,n)
+            print('Elliptical Slice Sample %d/%d' % (i,n))
         x, cur_ll = elliptical_slice(x, like.logprob, prior_L, prior_mu, cur_log_like=cur_ll)
         x_samples[:,i] = x.copy()
 
-    print 'Elliptical slice sampling took %f seconds' % (time.time() - current_time)
+    print('Elliptical slice sampling took %f seconds' % (time.time() - current_time))
 
     # Formula for the actual mean and covariance matrix below came from
     # the wikipedia page on conjugate priors
@@ -334,13 +334,13 @@ if __name__ == '__main__':
     B = spla.cho_solve((like_L, True), like_mu)
     actual_mean = np.dot(actual_cov, A+B)
 
-    print 'Actual mean:           %s' % actual_mean
-    print 'Mean of ESS samples:   %s' % np.mean(x_samples,axis=1)
+    print('Actual mean:           %s' % actual_mean)
+    print('Mean of ESS samples:   %s' % np.mean(x_samples,axis=1))
 
-    print 'Actual Cov:'
-    print actual_cov
-    print 'Cov of ESS samples:'
-    print np.cov(x_samples)
+    print('Actual Cov:')
+    print(actual_cov)
+    print('Cov of ESS samples:')
+    print(np.cov(x_samples))
 
     # below: also compare with regular slice sampling (slower)
 

--- a/spearmint/sampling/mcmc.py
+++ b/spearmint/sampling/mcmc.py
@@ -316,7 +316,7 @@ def slice_sample(init_x, logprob, *logprob_args, **slice_sample_args):
             new_z     = (upper - lower)*npr.rand() + lower
             new_llh   = dir_logprob(new_z)
             if np.isnan(new_llh):
-                print new_z, direction*new_z + init_x, new_llh, llh_s, init_x, logprob(init_x, *logprob_args)
+                print(new_z, direction*new_z + init_x, new_llh, llh_s, init_x, logprob(init_x, *logprob_args))
                 raise Exception("Slice sampler got a NaN")
             if new_llh > llh_s and acceptable(new_z, llh_s, start_lower, start_upper):
                 break
@@ -328,7 +328,7 @@ def slice_sample(init_x, logprob, *logprob_args, **slice_sample_args):
                 raise Exception("Slice sampler shrank to zero!")
 
         if verbose:
-            print "Steps Out:", l_steps_out, u_steps_out, " Steps In:", steps_in
+            print("Steps Out:", l_steps_out, u_steps_out, " Steps In:", steps_in)
 
         return new_z*direction + init_x, new_llh
 
@@ -340,7 +340,7 @@ def slice_sample(init_x, logprob, *logprob_args, **slice_sample_args):
 
     dims = init_x.shape[0]
     if compwise:
-        ordering = range(dims)
+        ordering = list(range(dims))
         npr.shuffle(ordering)
         new_x = init_x.copy()
         for d in ordering:
@@ -377,7 +377,7 @@ def slice_sample_simple(init_x, logprob, *logprob_args, **slice_sample_args):
             try:
                 return logprob(direction*z + init_x, *logprob_args)
             except:
-                print 'ERROR: Logprob failed at input %s' % str(direction*z + init_x)
+                print('ERROR: Logprob failed at input %s' % str(direction*z + init_x))
                 raise
                 
     
@@ -407,7 +407,7 @@ def slice_sample_simple(init_x, logprob, *logprob_args, **slice_sample_args):
             new_z     = (upper - lower)*npr.rand() + lower  # uniformly sample between upper and lower
             new_llh   = dir_logprob(new_z)  # new current logprob
             if np.isnan(new_llh):
-                print new_z, direction*new_z + init_x, new_llh, llh_s, init_x, logprob(init_x)
+                print(new_z, direction*new_z + init_x, new_llh, llh_s, init_x, logprob(init_x))
                 raise Exception("Slice sampler got a NaN logprob")
             if new_llh > llh_s:  # this is the termination condition
                 break       # it says, if you got to a better place than you started, you're done
@@ -422,7 +422,7 @@ def slice_sample_simple(init_x, logprob, *logprob_args, **slice_sample_args):
                 raise Exception("Slice sampler shrank to zero!")
 
         if verbose:
-            print "Steps Out:", l_steps_out, u_steps_out, " Steps In:", steps_in, "Final logprob:", new_llh
+            print("Steps Out:", l_steps_out, u_steps_out, " Steps In:", steps_in, "Final logprob:", new_llh)
 
         # return new the point
         return new_z*direction + init_x, new_llh
@@ -443,7 +443,7 @@ def slice_sample_simple(init_x, logprob, *logprob_args, **slice_sample_args):
 
     dims = init_x.shape[0]
     if compwise:   # if component-wise (independent) sampling
-        ordering = range(dims)
+        ordering = list(range(dims))
         npr.shuffle(ordering)
         cur_x = init_x.copy()
         for d in ordering:
@@ -472,7 +472,7 @@ if __name__ == '__main__':
 
     iters = 1000
     samps = np.zeros((iters,D))
-    for ii in xrange(1,iters):
+    for ii in range(1,iters):
         samps[ii,:] = slice_sample(samps[ii-1,:], fn, sigma=0.1, step_out=False, doubling_step=True, verbose=False)
 
     ll = -0.5*np.sum(samps**2, axis=1)

--- a/spearmint/sampling/slice_sampler.py
+++ b/spearmint/sampling/slice_sampler.py
@@ -228,9 +228,9 @@ class SliceSampler(AbstractSampler):
             lp += param.prior_logprob()
 
             if np.isnan(lp): # Positive infinity should be ok, right?
-                print 'Param diagnostics:'
+                print('Param diagnostics:')
                 param.print_diagnostics()
-                print 'Prior logprob: %f' % param.prior_logprob()
+                print('Prior logprob: %f' % param.prior_logprob())
                 raise Exception("Prior returned %f logprob" % lp)
 
         if not np.isfinite(lp):
@@ -257,7 +257,7 @@ class SliceSampler(AbstractSampler):
         """
         # turn self.params into a 1d numpy array
         params_array = hyperparameter_utils.params_to_array(self.params)
-        for i in xrange(self.thinning + 1):
+        for i in range(self.thinning + 1):
             # get a new value for the parameter array via slice sampling
             params_array, current_ll = slice_sample(params_array, self.logprob, model, **self.sampler_options)
             hyperparameter_utils.set_params_from_array(self.params, params_array) # Can this be untabbed safely?
@@ -280,15 +280,15 @@ if __name__ == '__main__':
 
     gsn = priors.Gaussian(mu = -1, sigma = 4)
 
-    for i in xrange(n):
+    for i in range(n):
         if i % 1000 == 0:
-            print 'Sample %d/%d' % (i,n)
+            print('Sample %d/%d' % (i,n))
 
         x, cur_ll = slice_sample(x, gsn. logprob)
         x_samples[i] = x.copy()
 
-    print '1D Gaussian actual mean: %f, mean of samples: %f' % (-1, np.mean(x_samples))
-    print '1D Gaussian actual sigma: %f, std of samples: %f' % (4, np.std(x_samples))
+    print('1D Gaussian actual mean: %f, mean of samples: %f' % (-1, np.mean(x_samples)))
+    print('1D Gaussian actual sigma: %f, std of samples: %f' % (4, np.std(x_samples)))
 
 
     plt.figure(1)
@@ -305,21 +305,21 @@ if __name__ == '__main__':
     x_samples = np.zeros((2,n))
     x = np.zeros(2)
 
-    for i in xrange(n):
+    for i in range(n):
         if i % 1000 == 0:
-            print 'Sample %d/%d' % (i,n)
+            print('Sample %d/%d' % (i,n))
 
         x, cur_ll = slice_sample(x, mvn.logprob)
         x_samples[:,i] = x.copy()
 
     mu_samp = np.mean(x_samples,axis=1)
-    print '2D Gaussian:'
-    print 'Actual mean:     [%f,%f]' % (mu[0], mu[1])
-    print 'Mean of samples: [%f,%f]' % (mu_samp[0], mu_samp[1])
-    print 'Actual Cov:'
-    print str(cov)
-    print 'Cov of samples'
-    print str(np.cov(x_samples))
+    print('2D Gaussian:')
+    print('Actual mean:     [%f,%f]' % (mu[0], mu[1]))
+    print('Mean of samples: [%f,%f]' % (mu_samp[0], mu_samp[1]))
+    print('Actual Cov:')
+    print(str(cov))
+    print('Cov of samples')
+    print(str(np.cov(x_samples)))
 
     # plt.figure(1)
     # plt.clf()

--- a/spearmint/sampling/whitened_prior_slice_sampler.py
+++ b/spearmint/sampling/whitened_prior_slice_sampler.py
@@ -227,7 +227,7 @@ class WhitenedPriorSliceSampler(AbstractSampler):
         return lp
 
     def sample(self, model):
-        for i in xrange(self.thinning + 1):
+        for i in range(self.thinning + 1):
             params_array, new_latent_values, current_ll = self.sample_fun(model, **self.sampler_options)
             hyperparameter_utils.set_params_from_array(self.params, params_array)
             model.latent_values.set_value(new_latent_values)
@@ -266,15 +266,15 @@ if __name__ == '__main__':
 
     gsn = priors.Gaussian(mu = -1, sigma = 4)
 
-    for i in xrange(n):
+    for i in range(n):
         if i % 1000 == 0:
-            print 'Sample %d/%d' % (i,n)
+            print('Sample %d/%d' % (i,n))
 
         x, cur_ll = slice_sample(x, gsn. logprob)
         x_samples[i] = x.copy()
 
-    print '1D Gaussian actual mean: %f, mean of samples: %f' % (-1, np.mean(x_samples))
-    print '1D Gaussian actual sigma: %f, std of samples: %f' % (4, np.std(x_samples))
+    print('1D Gaussian actual mean: %f, mean of samples: %f' % (-1, np.mean(x_samples)))
+    print('1D Gaussian actual sigma: %f, std of samples: %f' % (4, np.std(x_samples)))
 
 
     plt.figure(1)
@@ -291,21 +291,21 @@ if __name__ == '__main__':
     x_samples = np.zeros((2,n))
     x = np.zeros(2)
 
-    for i in xrange(n):
+    for i in range(n):
         if i % 1000 == 0:
-            print 'Sample %d/%d' % (i,n)
+            print('Sample %d/%d' % (i,n))
 
         x, cur_ll = slice_sample(x, mvn.logprob)
         x_samples[:,i] = x.copy()
 
     mu_samp = np.mean(x_samples,axis=1)
-    print '2D Gaussian:'
-    print 'Actual mean:     [%f,%f]' % (mu[0], mu[1])
-    print 'Mean of samples: [%f,%f]' % (mu_samp[0], mu_samp[1])
-    print 'Actual Cov:'
-    print str(cov)
-    print 'Cov of samples'
-    print str(np.cov(x_samples))
+    print('2D Gaussian:')
+    print('Actual mean:     [%f,%f]' % (mu[0], mu[1]))
+    print('Mean of samples: [%f,%f]' % (mu_samp[0], mu_samp[1]))
+    print('Actual Cov:')
+    print(str(cov))
+    print('Cov of samples')
+    print(str(np.cov(x_samples)))
 
     # plt.figure(1)
     # plt.clf()

--- a/spearmint/schedulers/PBS.py
+++ b/spearmint/schedulers/PBS.py
@@ -184,9 +184,9 @@
 
 import sys
 import spearmint
-from cluster_scheduler import AbstractClusterScheduler
+from .cluster_scheduler import AbstractClusterScheduler
 # Torque PBS scheduler python code from: https://oss.trac.surfsara.nl/pbs_python/
-import pbs
+from . import pbs
 from PBSQuery import PBSQuery
 
 def init(*args, **kwargs):

--- a/spearmint/schedulers/SGE.py
+++ b/spearmint/schedulers/SGE.py
@@ -182,7 +182,7 @@
 # to enter into this License and Terms of Use on behalf of itself and
 # its Institution.
 
-from cluster_scheduler import AbstractClusterScheduler
+from .cluster_scheduler import AbstractClusterScheduler
 
 def init(*args, **kwargs):
     return SGEScheduler(*args, **kwargs)

--- a/spearmint/schedulers/SLURM.py
+++ b/spearmint/schedulers/SLURM.py
@@ -183,7 +183,7 @@
 # its Institution.
 
 import spearmint
-from cluster_scheduler import AbstractClusterScheduler
+from .cluster_scheduler import AbstractClusterScheduler
 
 def init(*args, **kwargs):
     return SLURMScheduler(*args, **kwargs)

--- a/spearmint/schedulers/abstract_scheduler.py
+++ b/spearmint/schedulers/abstract_scheduler.py
@@ -185,9 +185,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-class AbstractScheduler(object):
-    __metaclass__ = ABCMeta
-
+class AbstractScheduler(object, metaclass=ABCMeta):
     def __init__(self, options):
         self.options = options
         

--- a/spearmint/schedulers/cluster_scheduler.py
+++ b/spearmint/schedulers/cluster_scheduler.py
@@ -194,9 +194,7 @@ from abc import ABCMeta, abstractmethod
 def init(*args, **kwargs):
     return AbstractClusterScheduler(*args, **kwargs)
 
-class AbstractClusterScheduler(object):
-    __metaclass__ = ABCMeta
-    
+class AbstractClusterScheduler(object, metaclass=ABCMeta):
     def __init__(self, options):
         self.options = options
     

--- a/spearmint/schedulers/local.py
+++ b/spearmint/schedulers/local.py
@@ -183,7 +183,7 @@
 # its Institution.
 
 import spearmint
-from abstract_scheduler import AbstractScheduler
+from .abstract_scheduler import AbstractScheduler
 import os
 import subprocess
 import sys

--- a/spearmint/tasks/base_task.py
+++ b/spearmint/tasks/base_task.py
@@ -207,7 +207,7 @@ class BaseTask(object):
         cardinality    = 0 # The number of distinct variables
         num_dims       = 0 # The number of dimensions in the matrix representation
 
-        for name, variable in variables_config.iteritems():
+        for name, variable in variables_config.items():
             cardinality += variable['size']
             vdict = {'type'    : variable['type'].lower(),
                      'indices' : []} # indices stores a mapping from these variable(s) to their matrix column(s)
@@ -223,7 +223,7 @@ class BaseTask(object):
             else:
                 raise Exception("Unknown variable type.")
 
-            for i in xrange(variable['size']):
+            for i in range(variable['size']):
                 if vdict['type'] == 'int':
                     vdict['indices'].append(num_dims)
                     num_dims += 1
@@ -250,7 +250,7 @@ class BaseTask(object):
         sys.stderr.write(indentation)
         sys.stderr.write('----          ----       -----\n')
 
-        for param_name, param in params.iteritems():
+        for param_name, param in params.items():
 
             if param['type'] == 'float':
                 format_str = '%s%-12.12s  %-9.9s  %-12f\n'
@@ -259,7 +259,7 @@ class BaseTask(object):
             else:
                 format_str = '%s%-12.12s  %-9.9s  %-12d\n'
 
-            for i in xrange(len(param['values'])):
+            for i in range(len(param['values'])):
                 if i == 0:
                     sys.stderr.write(format_str % (indentation, param_name, param['type'], param['values'][i]))
                 else:
@@ -271,7 +271,7 @@ class BaseTask(object):
             raise Exception('Input to paramify must be a 1-D array.')
 
         params = {}
-        for name, vdict in self.variables_meta.iteritems():
+        for name, vdict in self.variables_meta.items():
             indices = vdict['indices']
             params[name] = {}
             params[name]['type'] = vdict['type']
@@ -290,7 +290,7 @@ class BaseTask(object):
     # Converts a dict of params to the corresponding vector in puts space
     def vectorify(self, params):
         v = np.zeros(self.num_dims)
-        for name, param in params.iteritems():
+        for name, param in params.items():
             indices = self.variables_meta[name]['indices']
 
             if param['type'] == 'int' or param['type'] == 'float':
@@ -316,7 +316,7 @@ class BaseTask(object):
             squeeze = False
 
         U = np.zeros(V.shape)
-        for name, variable in self.variables_meta.iteritems():
+        for name, variable in self.variables_meta.items():
             indices = variable['indices']
             if variable['type'] == 'int':
                 vals = V[:,indices]
@@ -346,7 +346,7 @@ class BaseTask(object):
             squeeze = False
 
         V = np.zeros(U.shape)
-        for name, variable in self.variables_meta.iteritems():
+        for name, variable in self.variables_meta.items():
             indices = variable['indices']
             if variable['type'] == 'int':
                 vals = U[:,indices]

--- a/spearmint/tasks/task_group.py
+++ b/spearmint/tasks/task_group.py
@@ -203,7 +203,7 @@ class TaskGroup(object):
     
     def __init__(self, tasks_config, variables_config):
         self.tasks = {}
-        for task_name, task_options in tasks_config.iteritems():
+        for task_name, task_options in tasks_config.items():
             self.tasks[task_name] = Task(task_name,
                                          task_options,
                                          variables_config)
@@ -229,7 +229,7 @@ class TaskGroup(object):
     @inputs.setter
     def inputs(self, inputs):
         self._inputs = inputs
-        for task in self.tasks.values():
+        for task in list(self.tasks.values()):
             task.inputs = inputs
 
     @property
@@ -239,13 +239,13 @@ class TaskGroup(object):
     @pending.setter
     def pending(self, pending):
         self._pending = pending
-        for task in self.tasks.values():
+        for task in list(self.tasks.values()):
             task.pending = pending
 
     @property
     def values(self):
         """return a dictionary of the task values keyed by task name"""
-        return {task_name : task.values for task_name, task in self.tasks.iteritems()}
+        return {task_name : task.values for task_name, task in self.tasks.items()}
 
     @values.setter
     def values(self, values):
@@ -255,7 +255,7 @@ class TaskGroup(object):
             task.values = values[task_name]
 
     def add_nan_task_if_nans(self):
-        valids = np.vstack([vals for vals in self.values.values()]).sum(0)
+        valids = np.vstack([vals for vals in list(self.values.values())]).sum(0)
 
         if np.any(np.isnan(valids)):
                 

--- a/spearmint/tests/kernels/test_matern.py
+++ b/spearmint/tests/kernels/test_matern.py
@@ -204,8 +204,8 @@ def test_matern_grad():
     dloss = kernel.cross_cov_grad_data(data1, data2).sum(0)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(M):
-        for j in xrange(D):
+    for i in range(M):
+        for j in range(D):
             data2[i,j] += eps
             loss_1 = np.sum(kernel.cross_cov(data1, data2))
             data2[i,j] -= 2*eps

--- a/spearmint/tests/kernels/test_product_kernel.py
+++ b/spearmint/tests/kernels/test_product_kernel.py
@@ -207,8 +207,8 @@ def test_product_kernel_grad():
     dloss = kernel.cross_cov_grad_data(data1, data2).sum(0)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(M):
-        for j in xrange(D):
+    for i in range(M):
+        for j in range(D):
             data2[i,j] += eps
             loss_1 = np.sum(kernel.cross_cov(data1, data2))
             data2[i,j] -= 2*eps

--- a/spearmint/tests/kernels/test_scale.py
+++ b/spearmint/tests/kernels/test_scale.py
@@ -205,8 +205,8 @@ def test_grad():
     dloss = kernel.cross_cov_grad_data(data1, data2).sum(0)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(M):
-        for j in xrange(D):
+    for i in range(M):
+        for j in range(D):
             data2[i,j] += eps
             loss_1 = np.sum(kernel.cross_cov(data1, data2))
             data2[i,j] -= 2*eps

--- a/spearmint/tests/kernels/test_subset.py
+++ b/spearmint/tests/kernels/test_subset.py
@@ -205,8 +205,8 @@ def test_grad():
     dloss = kernel.cross_cov_grad_data(data1, data2).sum(0)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(M):
-        for j in xrange(D):
+    for i in range(M):
+        for j in range(D):
             data2[i,j] += eps
             loss_1 = np.sum(kernel.cross_cov(data1, data2))
             data2[i,j] -= 2*eps
@@ -214,8 +214,8 @@ def test_grad():
             data2[i,j] += eps
             dloss_est[i,j] = ((loss_1 - loss_2) / (2*eps))
 
-    print 'Subset kernel grad using indices %s:' % inds
-    print dloss
+    print('Subset kernel grad using indices %s:' % inds)
+    print(dloss)
 
     assert np.linalg.norm(dloss - dloss_est) < 1e-6
 

--- a/spearmint/tests/kernels/test_sum_kernel.py
+++ b/spearmint/tests/kernels/test_sum_kernel.py
@@ -207,8 +207,8 @@ def test_sum_kernel_grad():
     dloss = kernel.cross_cov_grad_data(data1, data2).sum(0)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(M):
-        for j in xrange(D):
+    for i in range(M):
+        for j in range(D):
             data2[i,j] += eps
             loss_1 = np.sum(kernel.cross_cov(data1, data2))
             data2[i,j] -= 2*eps

--- a/spearmint/tests/kernels/test_transform_kernel.py
+++ b/spearmint/tests/kernels/test_transform_kernel.py
@@ -214,8 +214,8 @@ def test_grad():
     dloss = kernel.cross_cov_grad_data(data1, data2).sum(0)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(M):
-        for j in xrange(D):
+    for i in range(M):
+        for j in range(D):
             data2[i,j] += eps
             loss_1 = np.sum(kernel.cross_cov(data1, data2))
             data2[i,j] -= 2*eps

--- a/spearmint/tests/models/in_progress/gp.py
+++ b/spearmint/tests/models/in_progress/gp.py
@@ -221,7 +221,7 @@ class DiagnosticGP(GP):
     # https://hips.seas.harvard.edu/blog/2013/06/10/testing-mcmc-code-part-2-integration-tests/
     # This test uses an arbitrary statistic of the data (outputs). Here we use the sum.
     def geweke_correctness_test(self):
-        print 'Initiating Geweke Correctness test'
+        print('Initiating Geweke Correctness test')
         # Note: the horseshoe prior on the noise will make the line slightly not straight
         # because we don't have the actual log pdf
 
@@ -230,7 +230,7 @@ class DiagnosticGP(GP):
         # First, check that all priors and models can be sampled from
         for param in self.hypers:
             if not hasattr(param.prior, 'sample'):
-                print 'Prior of param %s cannot be sampled from. Cannot perform the Geweke correctness test.' % param.name
+                print('Prior of param %s cannot be sampled from. Cannot perform the Geweke correctness test.' % param.name)
                 return
 
         n = 10000 # number of samples # n = self.mcmc_iters
@@ -242,9 +242,9 @@ class DiagnosticGP(GP):
             # 1) Draw new hypers from priors
             # 2) Draw new data given hypers (**NOT** given hypers and data !!!!)
         caseA = np.zeros(n)
-        for i in xrange(n):
+        for i in range(n):
             if i % 1000 == 0:
-                print 'Geweke Part A Sample %d/%d' % (i,n)
+                print('Geweke Part A Sample %d/%d' % (i,n))
             for param in self.hypers:
                 param.sample_from_prior()
             latent_y = self.sample_from_prior_given_hypers(self.data) # only inputs used
@@ -261,9 +261,9 @@ class DiagnosticGP(GP):
             # 2) Resample data given hypers
             # repeat a bunch of times
         caseB = np.zeros(n)
-        for i in xrange(n):
+        for i in range(n):
             if i % 1000 == 0:
-                print 'Geweke Part B Sample %d/%d' % (i,n)
+                print('Geweke Part B Sample %d/%d' % (i,n))
             # Take MCMC step on theta given data
             self.sampler.generate_sample() # data['inputs'] and data['values'] used
 
@@ -277,10 +277,10 @@ class DiagnosticGP(GP):
 
             caseB[i] = statistic_of_interest(self.data['values'])
         
-        print np.mean(caseA)
-        print np.std(caseA)
-        print np.mean(caseB)
-        print np.std(caseB)
+        print(np.mean(caseA))
+        print(np.std(caseA))
+        print(np.mean(caseB))
+        print(np.std(caseB))
 
         # Then, sort the sets A and B.
         caseA = np.sort(caseA)
@@ -288,7 +288,7 @@ class DiagnosticGP(GP):
 
         # Then for each a in A, take the fraction of B smaller than it. 
         yAxis = np.zeros(n)
-        for i in xrange(n):
+        for i in range(n):
             yAxis[i] = np.sum(caseB < caseA[i]) / float(n)
 
         xAxis = np.arange(n)/float(n)

--- a/spearmint/tests/models/test_gp.py
+++ b/spearmint/tests/models/test_gp.py
@@ -206,7 +206,7 @@ def test_fit():
     gp.fit(inputs, vals, pending)
 
     assert gp.chain_length == 15
-    assert all([np.all(p.value != p.initial_value) for p in gp.params.values()])
+    assert all([np.all(p.value != p.initial_value) for p in list(gp.params.values())])
     assert len(gp._cache_list) == 10
     assert len(gp._hypers_list) == 10
     assert len(gp._fantasy_values_list) == 10
@@ -264,8 +264,8 @@ def test_predict():
     dloss = 2*(dmu*mu[:,np.newaxis,:]).sum(2) + 2*(v[:,np.newaxis,np.newaxis]*dv).sum(2)
 
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(Ntest):
-        for j in xrange(D):
+    for i in range(Ntest):
+        for j in range(D):
             pred[i,j] += eps
             mu, v = gp.predict(pred)
             loss_1 = np.sum(mu**2) + np.sum(v**2)

--- a/spearmint/tests/models/test_gp_classifier.py
+++ b/spearmint/tests/models/test_gp_classifier.py
@@ -211,7 +211,7 @@ def test_fit():
     gp.fit(inputs, vals, pending)
 
     probs = np.zeros(inputs.shape[0])
-    for i in xrange(gp.num_states):
+    for i in range(gp.num_states):
         gp.set_state(i)
         probs += (gp.latent_values.value > 0) / float(mcmc_iters)
 
@@ -222,7 +222,7 @@ def test_fit():
     assert gp.values.shape[1] == 2
 
     assert gp.chain_length == burnin + mcmc_iters
-    assert all([np.all(p.value != p.initial_value) for p in gp.params.values()])
+    assert all([np.all(p.value != p.initial_value) for p in list(gp.params.values())])
     assert len(gp._cache_list) == mcmc_iters
     assert len(gp._hypers_list) == mcmc_iters
     assert len(gp._latent_values_list) == mcmc_iters
@@ -275,8 +275,8 @@ def test_predict():
     dloss = 2*(dmu*mu[:,np.newaxis,:]).sum(2) + 2*(v[:,np.newaxis,np.newaxis]*dv).sum(2)
 
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(Ntest):
-        for j in xrange(D):
+    for i in range(Ntest):
+        for j in range(D):
             pred[i,j] += eps
             mu, v = gp.predict(pred)
             loss_1 = np.sum(mu**2) + np.sum(v**2)

--- a/spearmint/tests/tasks/test_task.py
+++ b/spearmint/tests/tasks/test_task.py
@@ -210,8 +210,8 @@ def create_task():
 
     # Create a set of inputs that satisfies the constraints of each variable
     X = np.zeros((10,num_dims))
-    for i in xrange(10):
-        for name, variable in variables_meta.iteritems():
+    for i in range(10):
+        for name, variable in variables_meta.items():
             indices = variable['indices']
             if variable['type'] == 'int':
                 X[i,indices] = np.random.randint(variable['min'], variable['max']+1, len(indices))

--- a/spearmint/tests/transformations/test_linear.py
+++ b/spearmint/tests/transformations/test_linear.py
@@ -208,8 +208,8 @@ def test_backward_pass():
     dloss = lin.backward_pass(V)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(N):
-        for j in xrange(D):
+    for i in range(N):
+        for j in range(D):
             data[i,j] += eps
             loss_1 = np.sum(lin.forward_pass(data)**2)
             data[i,j] -= 2*eps

--- a/spearmint/tests/transformations/test_norm_lin.py
+++ b/spearmint/tests/transformations/test_norm_lin.py
@@ -208,8 +208,8 @@ def test_backward_pass():
     dloss = nl.backward_pass(V)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(N):
-        for j in xrange(D):
+    for i in range(N):
+        for j in range(D):
             data[i,j] += eps
             loss_1 = np.sum(nl.forward_pass(data)**2)
             data[i,j] -= 2*eps

--- a/spearmint/tests/transformations/test_normalization.py
+++ b/spearmint/tests/transformations/test_normalization.py
@@ -208,8 +208,8 @@ def test_backward_pass():
     dloss = n.backward_pass(V)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(N):
-        for j in xrange(D):
+    for i in range(N):
+        for j in range(D):
             data[i,j] += eps
             loss_1 = np.sum(n.forward_pass(data)**2)
             data[i,j] -= 2*eps

--- a/spearmint/tests/transformations/test_transformer.py
+++ b/spearmint/tests/transformations/test_transformer.py
@@ -305,8 +305,8 @@ def test_backward_pass():
     dloss = t.backward_pass(V)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(N):
-        for j in xrange(D):
+    for i in range(N):
+        for j in range(D):
             data[i,j] += eps
             loss_1 = np.sum(t.forward_pass(data)**2)
             data[i,j] -= 2*eps
@@ -326,8 +326,8 @@ def test_backward_pass():
     dloss = t.backward_pass(V)
     
     dloss_est = np.zeros(dloss.shape)
-    for i in xrange(N):
-        for j in xrange(D):
+    for i in range(N):
+        for j in range(D):
             data[i,j] += eps
             loss_1 = np.sum(t.forward_pass(data)**2)
             data[i,j] -= 2*eps
@@ -405,5 +405,5 @@ def test_add_layer():
 
     output_inds = t.add_layer(st3)
     assert len(t.layer_transformations) == 2
-    assert output_inds == range(10)
+    assert output_inds == list(range(10))
 

--- a/spearmint/transformations/__init__.py
+++ b/spearmint/transformations/__init__.py
@@ -1,9 +1,9 @@
-from beta_warp     import BetaWarp
-from ignore_dims   import IgnoreDims
-from kumar_warp    import KumarWarp
-from normalization import Normalization
-from linear        import Linear
-from transformer   import Transformer
-from norm_lin      import NormLin
+from .beta_warp     import BetaWarp
+from .ignore_dims   import IgnoreDims
+from .kumar_warp    import KumarWarp
+from .normalization import Normalization
+from .linear        import Linear
+from .transformer   import Transformer
+from .norm_lin      import NormLin
 
 __all__ = ["BetaWarp", "IgnoreDims", "KumarWarp", "Normalization", "Linear", "Transformer", "NormLin"]

--- a/spearmint/transformations/abstract_transformation.py
+++ b/spearmint/transformations/abstract_transformation.py
@@ -186,9 +186,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class AbstractTransformation(object):
-    __metaclass__ = ABCMeta
-
+class AbstractTransformation(object, metaclass=ABCMeta):
     @property
     def hypers(self):
         return None

--- a/spearmint/transformations/transformer.py
+++ b/spearmint/transformations/transformer.py
@@ -209,9 +209,9 @@ class Transformer(object):
         if len(layer_transformations) == 1 and isinstance(layer_transformations[0], AbstractTransformation):
             assert layer_transformations[0].num_dims == num_input_dims, 'Transformation must have the same number of input dimensions as the transformer layer.'
             transformations = layer_transformations
-            t_inds = [range(num_input_dims)]
+            t_inds = [list(range(num_input_dims))]
         else:
-            transformations, t_inds = zip(*layer_transformations)
+            transformations, t_inds = list(zip(*layer_transformations))
 
         self.validate_layer(t_inds)
         
@@ -243,8 +243,8 @@ class Transformer(object):
             for i in inds:
                 counts[i] += 1
 
-        assert np.array(counts.keys()).max() < self.num_dims, 'Maximum index exceeds number of dimensions.'
-        assert all([count == 1 for count in counts.values()]), 'Each index may only be used once.'
+        assert np.array(list(counts.keys())).max() < self.num_dims, 'Maximum index exceeds number of dimensions.'
+        assert all([count == 1 for count in list(counts.values())]), 'Each index may only be used once.'
 
     def forward_pass(self, inputs):
         assert self.layer_transformations, 'Transformer should contain transformations.'

--- a/spearmint/transformations/transformer.py
+++ b/spearmint/transformations/transformer.py
@@ -270,11 +270,11 @@ class Transformer(object):
     def backward_pass(self, V):
         assert self.layer_transformations, 'Transformer should contain transformations.'
 
-        for transformations, t_inds, remaining_inds, output_num_dims in zip(
+        for transformations, t_inds, remaining_inds, output_num_dims in list(zip(
                 self.layer_transformations,
                 self.layer_inds,
                 self.layer_remaining_inds,
-                self.layer_output_dims)[::-1]:
+                self.layer_output_dims))[::-1]:
 
             JV = np.zeros(list(V.shape[:-1])+[len([i for inds in t_inds for i in inds]) + len(remaining_inds)])
             i = 0

--- a/spearmint/utils/cleanup.py
+++ b/spearmint/utils/cleanup.py
@@ -187,7 +187,7 @@ import os
 import sys
 import pymongo
 import json
-from parsing import parse_db_address
+from .parsing import parse_db_address
 
 
 def cleanup(path):
@@ -199,7 +199,7 @@ def cleanup(path):
         cfg = json.load(f)
 
     db_address = parse_db_address(cfg)
-    print 'Cleaning up experiment %s in database at %s' % (cfg["experiment-name"], db_address)
+    print('Cleaning up experiment %s in database at %s' % (cfg["experiment-name"], db_address))
 
     client = pymongo.MongoClient(db_address)
 

--- a/spearmint/utils/compression.py
+++ b/spearmint/utils/compression.py
@@ -201,7 +201,7 @@ def decompress_array(a):
 def compress_nested_container(u_container):
     if isinstance(u_container, dict):
         cdict = {}
-        for key, value in u_container.iteritems():
+        for key, value in u_container.items():
             if isinstance(value, dict) or isinstance(value, list):
                 cdict[key] = compress_nested_container(value)
             else:
@@ -226,14 +226,14 @@ def compress_nested_container(u_container):
 
 def decompress_nested_container(c_container):
     if isinstance(c_container, dict):
-        if c_container.has_key('ctype') and c_container['ctype'] == COMPRESS_TYPE:
+        if 'ctype' in c_container and c_container['ctype'] == COMPRESS_TYPE:
             try:
                 return decompress_array(c_container)
             except:
                 raise Exception('Container does not contain a valid array.')
         else:
             udict = {}
-            for key, value in c_container.iteritems():
+            for key, value in c_container.items():
                 if isinstance(value, dict) or isinstance(value, list):
                     udict[key] = decompress_nested_container(value)
                 else:

--- a/spearmint/utils/compression.py
+++ b/spearmint/utils/compression.py
@@ -183,6 +183,7 @@
 # its Institution.
 
 import zlib
+import base64
 import numpy as np
 
 COMPRESS_TYPE = 'compressed array'
@@ -192,11 +193,11 @@ COMPRESS_TYPE = 'compressed array'
 def compress_array(a):
     return {'ctype'  : COMPRESS_TYPE,
             'shape'  : list(a.shape),
-            'value'  : (zlib.compress(a).encode('base64'))}
+            'value'  : (base64.b64encode(zlib.compress(a)).decode())}
 
 # It takes about 0.15 seconds to decompress a 1000x1000 array on a 2011 Macbook air
 def decompress_array(a):
-    return np.fromstring(zlib.decompress(a['value'].decode('base64'))).reshape(a['shape'])
+    return np.fromstring(zlib.decompress(base64.b64decode(a['value']))).reshape(a['shape'])
 
 def compress_nested_container(u_container):
     if isinstance(u_container, dict):

--- a/spearmint/utils/database/abstractdb.py
+++ b/spearmint/utils/database/abstractdb.py
@@ -185,9 +185,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-class AbstractDB(object):
-    __metaclass__ = ABCMeta
-
+class AbstractDB(object, metaclass=ABCMeta):
     @abstractmethod
     def save(self, collection_name):
         pass

--- a/spearmint/utils/database/mongodb.py
+++ b/spearmint/utils/database/mongodb.py
@@ -187,7 +187,7 @@ import time
 import pymongo
 import numpy.random as npr
 
-from abstractdb                  import AbstractDB
+from .abstractdb                  import AbstractDB
 from spearmint.utils.compression import compress_nested_container, decompress_nested_container
 
 class MongoDB(AbstractDB):

--- a/spearmint/utils/linalg.py
+++ b/spearmint/utils/linalg.py
@@ -245,7 +245,7 @@ def fast_chol_add(L, A):
                                compiler='gcc')
     except:
         k = np.arange(cols)
-        for i in xrange(cols):
+        for i in range(cols):
             j = rows-1;
             s = A[i,j] - np.dot(U[k[:i],i].T,U[k[:i],j])
             if i == j:

--- a/spearmint/utils/locker.py
+++ b/spearmint/utils/locker.py
@@ -213,12 +213,12 @@ class Locker:
         self.clear_locks()
 
     def clear_locks(self):
-        for filename in self.locks.keys():
+        for filename in list(self.locks.keys()):
             self.locks[filename] = 1
             self.unlock(filename)
 
     def lock(self, filename):
-        if self.locks.has_key(filename):
+        if filename in self.locks:
             self.locks[filename] += 1
             return True
         else:
@@ -246,7 +246,7 @@ class Locker:
     #        return not fail
 
     def unlock(self, filename):
-        if not self.locks.has_key(filename):
+        if filename not in self.locks:
             sys.stderr.write("Trying to unlock not-locked file %s.\n" % 
                              (filename))
             return True

--- a/spearmint/utils/param.py
+++ b/spearmint/utils/param.py
@@ -186,8 +186,8 @@ import copy
 
 import numpy as np
 
-import priors
-from compression import compress_array
+from . import priors
+from .compression import compress_array
 
 def set_params_from_array(params_iterable, params_array):
     """Update the params in params_iterable with the new values stored in params_array"""
@@ -272,6 +272,6 @@ class Param(object):
 
     def print_diagnostics(self):
         if self.size() == 1:
-            print '    %s: %s' % (self.name, self.value)
+            print('    %s: %s' % (self.name, self.value))
         else:
-            print '    %s: min=%s, max=%s (size=%d)' % (self.name, self.value.min(), self.value.max(), self.size())
+            print('    %s: min=%s, max=%s (size=%d)' % (self.name, self.value.min(), self.value.max(), self.size()))

--- a/spearmint/utils/parsing.py
+++ b/spearmint/utils/parsing.py
@@ -198,8 +198,7 @@ import json
 def unpack_args(str):
     if len(str) > 1:
         eq_re = re.compile("\s*=\s*")
-        return dict(map(lambda x: eq_re.split(x),
-                        re.compile("\s*,\s*").split(str)))
+        return dict([eq_re.split(x) for x in re.compile("\s*,\s*").split(str)])
     else:
         return {}
             

--- a/spearmint/utils/priors.py
+++ b/spearmint/utils/priors.py
@@ -191,9 +191,7 @@ from operator import add # same as lambda x,y:x+y I think
 
 
 
-class AbstractPrior(object):
-    __metaclass__ = ABCMeta
-
+class AbstractPrior(object, metaclass=ABCMeta):
     @abstractmethod
     def logprob(self, x):
         pass


### PR DESCRIPTION
In addition to the auto-conversion using 2to3, the following manual changes were applied:
- Deal with the change of zlib compress / decompress parameter type from str to bites (see utils/compression.py)
- Remove the inline C conversion using scipy.weave because weave is not supported in Python 3 scipy (see kernal/kernal_utils.py)